### PR TITLE
Fixed to support caption

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -10,7 +10,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-func Analyze(fileName string, caption bool) ([]table, error) {
+func Analyze(fileName string) ([]table, error) {
 	if fileName == "" {
 		return nil, fmt.Errorf("require markdown file")
 	}
@@ -32,6 +32,7 @@ func Analyze(fileName string, caption bool) ([]table, error) {
 	}
 
 	r := MDTReader{}
+	r.caption = Caption
 	if err := r.parse(f); err != nil {
 		return nil, err
 	}
@@ -41,7 +42,11 @@ func Analyze(fileName string, caption bool) ([]table, error) {
 		if err != nil {
 			return nil, err
 		}
-		table.tableName = strconv.Itoa(i)
+		if r.caption {
+			table.tableName = r.tableNames[i]
+		} else {
+			table.tableName = strconv.Itoa(i)
+		}
 		tables = append(tables, table)
 	}
 	return tables, nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,20 +12,21 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and analyze SQL dumps",
-	Long: `List and analyze SQL dumps from a specified file. This command parses the SQL dump file and displays information about the tables contained within.`,
+	Long: `List and analyze SQL dumps from a specified file.
+ This command parses the SQL dump file and displays information about the tables contained within.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fileName := ""
 		if len(args) >= 1 {
 			fileName = args[0]
 		}
-		if err := analyzeDump(fileName, Caption); err != nil {
+		if err := analyzeDump(fileName); err != nil {
 			log.Fatal(err)
 		}
 	},
 }
 
-func analyzeDump(fileName string, caption bool) error {
-	tables, err := mdtsql.Analyze(fileName, caption)
+func analyzeDump(fileName string) error {
+	tables, err := mdtsql.Analyze(fileName)
 	if err != nil {
 		return err
 	}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -11,8 +11,9 @@ import (
 // queryCmd represents the query command
 var queryCmd = &cobra.Command{
 	Use:   "query",
-	Short: "Execute SQL-like queries on tabular data",
-	Long: `Execute SQL-like queries on tabular data. This command allows you to run SQL queries against tables formatted in Markdown within the specified files.`,
+	Short: "Execute SQL queries on markdown table and tabular data",
+	Long: `Execute SQL queries on markdown table and tabular data.
+This command allows you to run SQL queries against tables formatted in Markdown within the specified files.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return exec(args)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/noborus/mdtsql"
 	"github.com/noborus/trdsql"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -56,9 +57,6 @@ var Ver bool
 // Debug is debug print.
 var Debug bool
 
-// Caption makes the text before the table the table name.
-var Caption bool
-
 // Delimiter is a delimiter specification (CSV ans RAW only).
 var Delimiter string
 
@@ -77,7 +75,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.mdtsql.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&Ver, "version", "v", false, "display version information")
 	rootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "", false, "debug print")
-	rootCmd.PersistentFlags().BoolVarP(&Caption, "caption", "c", false, "caption table name")
+	rootCmd.PersistentFlags().BoolVarP(&mdtsql.Caption, "caption", "c", false, "caption table name")
 	rootCmd.PersistentFlags().StringVarP(&Query, "query", "q", "", "SQL query")
 
 	rootCmd.PersistentFlags().StringVarP(&OutFormat, "OutFormat", "o", "md", "output format=at|csv|ltsv|json|jsonl|tbln|raw|md|vf|yaml")


### PR DESCRIPTION
Specify the table with a caption when the caption option is specified. Added a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced table name assignment logic to support multiple table names based on captions.
	- Refined the query command description to emphasize its focus on SQL queries for markdown tables and tabular data.
- **Refactor**
	- Simplified the `analyzeDump` function by removing the `caption` parameter for alignment with updated logic.
	- Updated `MDTReader` struct to include a `tableNames` field for handling multiple table names and improved initialization of `caption` settings.
- **Chores**
	- Updated import statements to use `mdtsql.Caption` for better flag handling in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->