### PR TITLE
Add support for fallback analyze

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -28,6 +28,7 @@ func Analyze(fileName string) ([]table, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer f.Close()
 		reader = f
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,10 +5,11 @@ import (
 	"os"
 
 	"github.com/noborus/mdtsql"
+	"github.com/noborus/trdsql"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
+// listCmd represents the list command.
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and analyze SQL dumps",
@@ -27,10 +28,15 @@ var listCmd = &cobra.Command{
 
 func analyzeDump(fileName string) error {
 	tables, err := mdtsql.Analyze(fileName)
-	if err != nil {
+	if err == nil {
+		mdtsql.Dump(os.Stdout, tables)
+		return nil
+	}
+
+	// fallback to trdsql.Analyze.
+	if err := trdsql.Analyze(fileName, trdsql.NewAnalyzeOpts(), trdsql.NewReadOpts()); err != nil {
 		return err
 	}
-	mdtsql.Dump(os.Stdout, tables)
 	return nil
 }
 

--- a/cmd/mdtsql/main.go
+++ b/cmd/mdtsql/main.go
@@ -2,10 +2,10 @@ package main
 
 import "github.com/noborus/mdtsql/cmd"
 
-// version represents the version
+// version represents the version.
 var version = "dev"
 
-// revision set "git rev-parse --short HEAD"
+// revision set "git rev-parse --short HEAD".
 var revision = "HEAD"
 
 func main() {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// queryCmd represents the query command
+// queryCmd represents the query command.
 var queryCmd = &cobra.Command{
 	Use:   "query",
 	Short: "Execute SQL queries on markdown table and tabular data",
@@ -20,11 +20,11 @@ This command allows you to run SQL queries against tables formatted in Markdown 
 }
 
 func exec(args []string) error {
+	trdsql.EnableMultipleQueries()
 	if Debug {
 		trdsql.EnableDebug()
 	}
-	query := strings.Join(args, " ")
-	trdsql.EnableMultipleQueries()
+
 	writer := newWriter(os.Stdout, os.Stderr)
 	trd := trdsql.NewTRDSQL(
 		trdsql.NewImporter(
@@ -33,6 +33,7 @@ func exec(args []string) error {
 		),
 		trdsql.NewExporter(writer),
 	)
+	query := strings.Join(args, " ")
 	return trd.Exec(query)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "mdtsql",
 	Args:  cobra.MinimumNArgs(1),
@@ -31,9 +31,9 @@ The result can be output to CSV, JSON, LTSV, YAML, Markdown, etc.`,
 }
 
 var (
-	// Version represents the version
+	// Version represents the version.
 	Version string
-	// Revision set "git rev-parse --short HEAD"
+	// Revision set "git rev-parse --short HEAD".
 	Revision string
 )
 

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tableCmd represents the table command
+// tableCmd represents the table command.
 var tableCmd = &cobra.Command{
 	Use: "table",
 
@@ -23,7 +23,6 @@ func execTable(table string) error {
 	if Debug {
 		trdsql.EnableDebug()
 	}
-	query := "SELECT * FROM " + table
 	writer := newWriter(os.Stdout, os.Stderr)
 	trd := trdsql.NewTRDSQL(
 		trdsql.NewImporter(
@@ -32,6 +31,7 @@ func execTable(table string) error {
 		),
 		trdsql.NewExporter(writer),
 	)
+	query := "SELECT * FROM " + table
 	return trd.Exec(query)
 }
 

--- a/table.go
+++ b/table.go
@@ -11,19 +11,22 @@ type table struct {
 	body      [][]interface{}
 }
 
+// Names returns the column names.
 func (t table) Names() ([]string, error) {
 	return t.names, nil
 }
 
+// Types returns the column types.
 func (t table) Types() ([]string, error) {
 	return t.types, nil
 }
 
-func (t table) PreReadRow() [][]interface{} {
+// PreReadRow returns the body.
+func (t table) PreReadRow() [][]any {
 	return t.body
 }
 
 // ReadRow only returns EOF.
-func (t table) ReadRow(row []interface{}) ([]interface{}, error) {
+func (t table) ReadRow(row []any) ([]any, error) {
 	return nil, io.EOF
 }


### PR DESCRIPTION
This commit adds support for fallback analyze. This feature is useful when the analyze command fails to analyze the table.

Fixed missing periods in comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced file input handling and error reporting in the Analyze function.
	- Added fallback analysis option for SQL dump files in the list command.
	- Introduced new methods for the table struct: `Names` and `Types`.

- **Bug Fixes**
	- Improved error handling and control flow in the analyzeDump function.

- **Documentation**
	- Updated comments for consistency across various commands.

- **Refactor**
	- Adjusted method signatures to use more generic types in the table struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->